### PR TITLE
Add cheese data API route

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,8 @@ dmypy.json
 **/data
 model/best_model02122020.pt
 *.pt
+
+# Node.js
+node_modules/
+.next/
+dist/

--- a/README.md
+++ b/README.md
@@ -135,3 +135,38 @@ In particular, focusing only on the residential area images we got on the test s
 
 ### Pre-trained models & data
 Both are available [here](https://drive.google.com/drive/folders/1nwEv1DNEPEkCbO4TQbw965zjbOVL-x5k?usp=sharing)
+
+## Web Interface
+
+A minimal Next.js application is available in `apps/web` and configured using Turborepo. To run the web interface you need Node.js and npm installed.
+
+### Install dependencies
+
+```bash
+npm install
+```
+
+### Start development server
+
+```bash
+npm run dev
+```
+
+This will start the Next.js server on <http://localhost:3000>. The Python code in this repository can be integrated by exposing APIs or running the existing scripts separately (e.g. `python run.py`) and connecting to them from the frontend.
+
+### Build
+
+```bash
+npm run build
+```
+
+
+### Cheese data API
+
+The Next.js app exposes a sample API route under `/api/cheese` that retrieves open data about cheeses from [OpenFoodFacts](https://world.openfoodfacts.org/). When the development server is running you can query it locally:
+
+```bash
+curl http://localhost:3000/api/cheese
+```
+
+This request returns a JSON payload with a list of cheeses including their names, brands and an image URL if available.

--- a/apps/web/app/api/cheese/route.js
+++ b/apps/web/app/api/cheese/route.js
@@ -1,0 +1,17 @@
+export async function GET() {
+  try {
+    const response = await fetch('https://world.openfoodfacts.org/category/cheeses.json');
+    if (!response.ok) {
+      return new Response('Failed to fetch cheese data', { status: 500 });
+    }
+    const data = await response.json();
+    const cheeses = (data.products || []).map(p => ({
+      name: p.product_name,
+      brands: p.brands,
+      image: p.image_front_url
+    }));
+    return Response.json({ cheeses });
+  } catch (err) {
+    return new Response('Error retrieving cheese data', { status: 500 });
+  }
+}

--- a/apps/web/app/page.js
+++ b/apps/web/app/page.js
@@ -1,0 +1,8 @@
+export default function Home() {
+  return (
+    <div>
+      <h1>Photovoltaic Detection</h1>
+      <p>Welcome to the web interface.</p>
+    </div>
+  );
+}

--- a/apps/web/jsconfig.json
+++ b/apps/web/jsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@ui/*": ["../../packages/ui/src/*"]
+    }
+  }
+}

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "web",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.2.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "photovoltaic-monorepo",
+  "private": true,
+  "workspaces": ["apps/*", "packages/*"],
+  "scripts": {
+    "dev": "turbo dev",
+    "build": "turbo build"
+  },
+  "devDependencies": {
+    "turbo": "^1.10.14"
+  }
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "ui",
+  "version": "0.0.0",
+  "private": true,
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "dependencies": {
+    "react": "^18.2.0"
+  }
+}

--- a/packages/ui/src/Button.tsx
+++ b/packages/ui/src/Button.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react';
+
+export function Button({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) {
+  return (
+    <button className="px-4 py-2 bg-blue-600 text-white rounded" {...props}>
+      {children}
+    </button>
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,0 +1,1 @@
+export * from './Button';

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "pipeline": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**", ".next/**"]
+    },
+    "dev": {
+      "cache": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- expose `/api/cheese` endpoint in the Next.js app to fetch OpenFoodFacts data
- document how to call the endpoint in README

## Testing
- `npm run build` *(fails: turbo not found)*