### PR TITLE
Add inference unit test

### DIFF
--- a/process_data/import_test.py
+++ b/process_data/import_test.py
@@ -1,35 +1,46 @@
 import numpy as np
-import matplotlib.pyplot  as plt
+import matplotlib.pyplot as plt
 import torch
-from torch.autograd import Variable
-from torchvision import transforms
-from torch.utils.data import DataLoader
-
-from model.unet import *
-from loss.loss import *
-from process_data.data_loader import *
-from hyperparameters.select_param import *
-from matplotlib import image
-from PIL import Image
 import cv2
 
+from model.unet import *
 
 
-def import_and_show(model,name):
-    fig = plt.figure()
-    fig.set_size_inches(12, 7, forward=True)
 
-    ax1 = fig.add_subplot(1,2,1)
-    ax1.title.set_text('Input Image')
-    ax2 = fig.add_subplot(1,2,2)
-    ax2.title.set_text('Predicted Label')
+def import_and_predict(model, name, show=False):
+    """Load an image, run prediction and optionally display the result."""
     image = cv2.imread(name)
-    test = np.asarray(cv2.resize(image,dsize=(250,250), interpolation=cv2.INTER_CUBIC))
-    test = test[:,:,[2,1,0]]
-    ax1.imshow(test)
-    test = torch.tensor(np.transpose(test))
-    test = test.float()
+    test = np.asarray(
+        cv2.resize(image, dsize=(250, 250), interpolation=cv2.INTER_CUBIC)
+    )
+    test = test[:, :, [2, 1, 0]]
 
-    ypred = torch.squeeze(model.predict(torch.unsqueeze(test,0).cuda())).cpu().detach().numpy()
-    ax2.imshow(np.transpose(np.around(ypred)))
-    plt.show()
+    if show:
+        fig = plt.figure()
+        fig.set_size_inches(12, 7, forward=True)
+        ax1 = fig.add_subplot(1, 2, 1)
+        ax1.title.set_text("Input Image")
+        ax1.imshow(test)
+
+    tensor = torch.tensor(np.transpose(test)).float()
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    pred = (
+        torch.squeeze(model.predict(torch.unsqueeze(tensor, 0).to(device)))
+        .cpu()
+        .detach()
+        .numpy()
+    )
+    mask = np.transpose(np.around(pred))
+
+    if show:
+        ax2 = fig.add_subplot(1, 2, 2)
+        ax2.title.set_text("Predicted Label")
+        ax2.imshow(mask)
+        plt.show()
+
+    return mask
+
+
+def import_and_show(model, name):
+    """Backward compatibility wrapper for displaying predictions."""
+    return import_and_predict(model, name, show=True)

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1,0 +1,19 @@
+import numpy as np
+from pathlib import Path
+
+from process_data.import_test import import_and_predict
+from model.unet import UNet
+
+
+def test_inference_output_shape_and_range():
+    # locate a sample image bundled with the repository
+    sample_image = Path('documents/figures/pred_full_1.png')
+    assert sample_image.exists(), 'sample image is missing'
+
+    model = UNet(3, 1, False)
+    model.eval()
+
+    mask = import_and_predict(model, str(sample_image))
+
+    assert mask.shape == (250, 250)
+    assert mask.min() >= 0 and mask.max() <= 1


### PR DESCRIPTION
## Summary
- refactor `import_and_show` into `import_and_predict`
- test inference output shape and value range

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_683b8f80ec8c8332846a81f536b940d6